### PR TITLE
Update FileAdder.php

### DIFF
--- a/src/MediaCollections/FileAdder.php
+++ b/src/MediaCollections/FileAdder.php
@@ -501,9 +501,9 @@ class FileAdder
 
             $class = $this->subject::class;
 
-            $class::created(function ($model) {
-                $model->processUnattachedMedia(function (Media $media, self $fileAdder) use ($model) {
-                    $this->processMediaItem($model, $media, $fileAdder);
+            $class::created(function () {
+                $this->subject->processUnattachedMedia(function (Media $media, self $fileAdder) {
+                    $this->processMediaItem($this->subject, $media, $fileAdder);
                 });
             });
 


### PR DESCRIPTION
Fix: Prevent model caching issue in Roadrunner event handler

This commit addresses an issue where the model was being cached by Roadrunner when processing the `created` event. This caused incorrect behavior when adding media to the model.

The fix replaces `$model` with `$this->subject` within the `processUnattachedMedia` callback to ensure the correct model instance is used.